### PR TITLE
Zeno.cpp

### DIFF
--- a/Zeno.cpp
+++ b/Zeno.cpp
@@ -2,7 +2,7 @@
 using namespace std;
 
 int factorial(int n) {
-    if (n = 0) return 1;
+    if (n == 0) return 1;
     int result = 1;
     for (int i = 1; i <= n; i++) {
         result = result * i; 


### PR DESCRIPTION
the statement: if(n=0) must be if(n==0). if it is not changed then the value of n will always be 0 below it and even in the if statement. so it will always give 1 whatever the value of n passed which is wrong